### PR TITLE
Add a proxy adapter for marshalling between connections

### DIFF
--- a/lib/nio/websocket.rb
+++ b/lib/nio/websocket.rb
@@ -63,7 +63,6 @@ module NIO
       # @param remote [String] remote server in "hostname_or_ip:port" format
       # @option options [Integer] :port required: Port on which to listen for incoming connections
       # @option options [String] :address optional: Specific Address on which to bind the TCPServer
-      # @option options [Hash] :websocket_options Hash to pass to the ::WebSocket::Driver.server
       # @option options [Hash] :ssl_context Hash from which to create the OpenSSL::SSL::SSLContext object
       # @yield [::WebSocket::Driver]
       # @return server, as passed in, or a new TCPServer if no server was specified

--- a/lib/nio/websocket.rb
+++ b/lib/nio/websocket.rb
@@ -8,6 +8,7 @@ require "logger"
 require "nio/websocket/reactor"
 require "nio/websocket/adapter/client"
 require "nio/websocket/adapter/server"
+require "nio/websocket/adapter/proxy"
 
 module NIO
   module WebSocket
@@ -57,6 +58,37 @@ module NIO
         adapter.driver
       end
 
+      # Establish a proxy host listening on the given port and address, that marshalls all data to/from a new connection on remote
+      # @param [Hash] options
+      # @param remote [String] remote server in "hostname_or_ip:port" format
+      # @option options [Integer] :port required: Port on which to listen for incoming connections
+      # @option options [String] :address optional: Specific Address on which to bind the TCPServer
+      # @option options [Hash] :websocket_options Hash to pass to the ::WebSocket::Driver.server
+      # @option options [Hash] :ssl_context Hash from which to create the OpenSSL::SSL::SSLContext object
+      # @yield [::WebSocket::Driver]
+      # @return server, as passed in, or a new TCPServer if no server was specified
+      def proxy(remote, options = {})
+        server = create_server(options)
+        host, port, extra = remote.split(":", 3)
+        raise "Specify the remote parameter in 'hostname_or_ip:port' format" if extra || port.to_i == 0 || host.empty?
+        Reactor.queue_task do
+          monitor = Reactor.selector.register(server, :r)
+          monitor.value = proc do
+            accept_socket server, options do |client|
+              srv = open_socket "tcp://#{remote}", options
+              adapter = PROXY_ADAPTER.new(srv, client, options)
+              Reactor.queue_task do
+                adapter.add_to_reactor
+              end
+              logger.info "Proxy connection established between #{srv} and #{client}"
+            end
+          end
+        end
+        logger.info "Proxy Host listening for new connections on port " + options[:port].to_s
+        Reactor.start
+        server
+      end
+
       # Start handling new connections, passing each through the supplied block
       # @param [Hash] options
       # @param server [TCPServer] (DI) TCPServer-like object to use in lieu of starting a new server
@@ -88,6 +120,7 @@ module NIO
 
       SERVER_ADAPTER = NIO::WebSocket::Adapter::Server
       CLIENT_ADAPTER = NIO::WebSocket::Adapter::Client
+      PROXY_ADAPTER = NIO::WebSocket::Adapter::Proxy
 
       # Resets this API to a fresh state
       def reset

--- a/lib/nio/websocket/adapter.rb
+++ b/lib/nio/websocket/adapter.rb
@@ -1,4 +1,4 @@
-require 'nio/websocket/raw_adapter'
+require "nio/websocket/raw_adapter"
 
 module NIO
   module WebSocket
@@ -20,6 +20,8 @@ module NIO
       attr_reader :driver
 
       def teardown
+        driver.force_state :closed
+        driver.emit :io_error
         @driver = nil # circular reference
         super
       end
@@ -27,13 +29,6 @@ module NIO
       def close(from = nil)
         driver.close if from.nil? && !closing
         super()
-      end
-
-      def add_to_reactor
-        super do
-          driver.force_state :closed
-          driver.emit :io_error
-        end
       end
 
       def read

--- a/lib/nio/websocket/adapter/proxy.rb
+++ b/lib/nio/websocket/adapter/proxy.rb
@@ -1,0 +1,18 @@
+require "nio/websocket/adapter"
+
+module NIO
+  module WebSocket
+    class Adapter
+      class Proxy < Adapter
+        def initialize(url, io, options)
+          @url = url
+          driver = ::WebSocket::Driver.client(self, options[:websocket_options] || {})
+          super io, driver, options
+          WebSocket.logger.debug "Initiating handshake on #{io}"
+          driver.start
+        end
+        attr_reader :url
+      end
+    end
+  end
+end

--- a/lib/nio/websocket/raw_adapter.rb
+++ b/lib/nio/websocket/raw_adapter.rb
@@ -1,0 +1,88 @@
+module NIO
+  module WebSocket
+    class RawAdapter
+      def initialize(io, options)
+        @inner = io
+        @options = options
+        @buffer = ""
+        @mutex = Mutex.new
+      end
+      attr_reader :inner, :options, :monitor, :closing
+
+      def teardown
+        monitor.close
+        inner.close
+      end
+
+      def close
+        return false if @closing
+
+        @closing = true
+        monitor.interests = :rw
+        Reactor.selector.wakeup
+        true
+      end
+
+      def add_to_reactor(&errorblock)
+        @monitor = Reactor.selector.register(inner, :rw) # This can block if this is the main thread and the reactor is busy
+        monitor.value = proc do
+          begin
+            read if monitor.readable?
+            pump_buffer if monitor.writable?
+          rescue Errno::ECONNRESET, EOFError, Errno::ECONNABORTED
+            yield if block_given?
+            teardown
+            WebSocket.logger.info "#{inner} socket closed"
+          rescue IO::WaitReadable # rubocop:disable Lint/HandleExceptions
+          rescue IO::WaitWritable
+            monitor.interests = :rw
+          end
+          if @closing
+            if !monitor.readable? && @buffer.empty?
+              teardown
+              WebSocket.logger.info "#{inner} closed"
+            else
+              monitor.interests = :rw unless monitor.closed? # keep the :w interest so that our block runs each time
+              # edge case: if monitor was readable this time, and the write buffer is empty, if we emptied the read buffer this time our block wouldn't run again
+            end
+          end
+        end
+      end
+
+      def read
+        data = inner.read_nonblock(16384)
+        if data
+          WebSocket.logger.debug { "Incoming data on #{inner}:\n#{data}" } if WebSocket.log_traffic?
+          yield data if block_given?
+        end
+        data
+      end
+
+      def write(data)
+        @mutex.synchronize do
+          @buffer << data
+        end
+        return unless monitor
+        pump_buffer
+        Reactor.selector.wakeup unless monitor.interests == :r
+      end
+
+      def pump_buffer
+        @mutex.synchronize do
+          written = 0
+          begin
+            written = inner.write_nonblock @buffer unless @buffer.empty?
+            WebSocket.logger.debug { "Pumped #{written} bytes of data from buffer to #{inner}:\n#{@buffer}" } unless @buffer.empty? || !WebSocket.log_traffic?
+            @buffer = @buffer.byteslice(written..-1) if written > 0
+            WebSocket.logger.debug { "The buffer is now:\n#{@buffer}" } unless @buffer.empty? || !WebSocket.log_traffic?
+          rescue IO::WaitWritable, IO::WaitReadable
+            return written
+          ensure
+            monitor.interests = @buffer.empty? ? :r : :rw
+          end
+          written
+        end
+      end
+    end
+  end
+end

--- a/lib/nio/websocket/raw_adapter.rb
+++ b/lib/nio/websocket/raw_adapter.rb
@@ -23,14 +23,13 @@ module NIO
         true
       end
 
-      def add_to_reactor(&errorblock)
+      def add_to_reactor
         @monitor = Reactor.selector.register(inner, :rw) # This can block if this is the main thread and the reactor is busy
         monitor.value = proc do
           begin
             read if monitor.readable?
             pump_buffer if monitor.writable?
           rescue Errno::ECONNRESET, EOFError, Errno::ECONNABORTED
-            yield if block_given?
             teardown
             WebSocket.logger.info "#{inner} socket closed"
           rescue IO::WaitReadable # rubocop:disable Lint/HandleExceptions

--- a/lib/nio/websocket/version.rb
+++ b/lib/nio/websocket/version.rb
@@ -1,5 +1,5 @@
 module NIO
   module WebSocket
-    VERSION = "0.6.3".freeze
+    VERSION = "0.7.0".freeze
   end
 end

--- a/spec/nio4r/websocket_spec.rb
+++ b/spec/nio4r/websocket_spec.rb
@@ -83,6 +83,10 @@ module WireUp
     @host
   end
 
+  def self.add_proxy(remote, options)
+    @proxy = NIO::WebSocket.proxy remote, options
+  end
+
   def self.add_client(client_driver)
     client_driver.on :message do |msg|
       @client.test_onmessage msg.data
@@ -104,6 +108,18 @@ describe NIO::WebSocket do
         WireUp.add_host host
       end
       NIO::WebSocket.connect "ws://localhost:8080" do |client|
+        WireUp.add_client client
+      end
+    end
+    include_examples "Core Tests"
+  end
+  context "ws://localhost:8081 via proxy" do
+    before :context do
+      NIO::WebSocket.listen port: 8081 do |host|
+        WireUp.add_host host
+      end
+      WireUp.add_proxy "localhost:8081", port: 8088
+      NIO::WebSocket.connect "ws://localhost:8088" do |client|
         WireUp.add_client client
       end
     end


### PR DESCRIPTION
This is just a raw TCP proxy

This works for ws://, but acted funny for wss:// - probably due to some ssl man in the middle prevention mechanism.  I'll fix that if it turns out that I need it or if I get the time.

Or if someone yells at me ;)

Usage:
```NIO::WebSocket.proxy 'destination:port', port: 8080```
listens on localhost:8080 and proxies the data to and fro a fresh connection to 'destination:port'
you may specify the same 'options' as on `NIO::WebSocket.listen`, except the websocket options - those are endpoint matters